### PR TITLE
KAS-5020 include getting file in try catch to prevent app crashing

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,11 +6,11 @@ import { execWithRetry } from "./lib/util";
 import { deleteFile, downloadPdf, uploadFile } from "./lib/graph-api";
 
 app.post("/files/:id/convert", async (req, res, next) => {
-  const fileId = req.params.id;
-  const file = await getFile(fileId);
-  file.path = file.physicalUri.replace("share://", "/share/");
-
   try {
+    const fileId = req.params.id;
+    const file = await getFile(fileId);
+    file.path = file.physicalUri.replace("share://", "/share/");
+
     const stats = fs.statSync(file.path);
     file.size = stats.size;
     const readStream = fs.createReadStream(file.path);

--- a/app.js
+++ b/app.js
@@ -14,6 +14,13 @@ app.post("/files/:id/convert", async (req, res, next) => {
     const stats = fs.statSync(file.path);
     file.size = stats.size;
     const readStream = fs.createReadStream(file.path);
+    
+    // If this fails this crashes the app if not caught.
+    readStream.on('error', function(err) {
+      console.log(`Error reading readStream: ${err.message}`);
+      // silence service crashing error, throwing here crashes
+      console.trace(err);
+    });
 
     await execWithRetry(() => uploadFile(file, readStream));
 
@@ -37,6 +44,7 @@ app.post("/files/:id/convert", async (req, res, next) => {
     });
   } catch (err) {
     console.log(`Error converting DOCX file: ${err.message}`);
+    console.trace(err);
     return next({ message: JSON.stringify(err.message), status: 500 });
   }
 });

--- a/lib/file.js
+++ b/lib/file.js
@@ -16,6 +16,7 @@ import { FILE_RESOURCE_BASE_URI, STORAGE_PATH } from '../cfg';
 /**
  * @param {string} id The id of the file to retrieve
  * @returns {Promise<any>} A record containing the id, name, extension and uris
+ * @throws if file could not be found in metadata
  */
 async function getFile(id) {
   const q = `PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
@@ -37,6 +38,9 @@ WHERE {
 }`;
   const result = await query(q);
   const [file] = parseSparqlResults(result);
+  if (!file?.id) {
+    throw new Error('could not find file to convert');
+  }
   file.isDraftFile = file.isDraftFile === '0'
     ? false
     : file.isDraftFile === '1'


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5020

In logs on the server I only found 1 error which is clearly the `getFile` failing.
The `getFile` was outside the current try catch, unsure why it failed since we did not keep database logs from that event.
It was however not during a database checkpoint (since those happen around HH:50, and the error was on HH:03, upload and POST call happened on HH:54. So the database didn't respond for 10 minutes in this call maybe?) 

Looking through current logs I found no recent errors.
