### PR TITLE
KAS-5050 check default drive on start and with cron job, email on failure

### DIFF
--- a/cfg.js
+++ b/cfg.js
@@ -27,7 +27,7 @@ const EMAIL_TO_ADDRESS_ON_FAILURE = process.env.EMAIL_TO_ADDRESS_ON_FAILURE ?? '
 
 const RESOURCE_BASE_URI  = 'http://themis.vlaanderen.be';
 const EMAIL_GRAPH_URI = "http://mu.semte.ch/graphs/system/email";
-const EMAIL_OUTBOX_URI = "http://themis.vlaanderen.be/id/mail-folders/d9a415a4-b5e5-41d0-80ee-3f85d69e318c";
+const EMAIL_OUTBOX_URI = "http://themis.vlaanderen.be/id/mail-folders/4296e6af-7d4f-423d-ba89-ed4cbbb33ae7";
 
 const RELATIVE_STORAGE_PATH = rstrip(process.env.MU_APPLICATION_FILE_STORAGE_PATH ?? "converted-docx", "/")
 const STORAGE_PATH = `/share/${RELATIVE_STORAGE_PATH}`;

--- a/cfg.js
+++ b/cfg.js
@@ -21,6 +21,13 @@ const TENANT_ID = process.env.TENANT_ID;
 const CLIENT_ID = process.env.CLIENT_ID;
 const CLIENT_SECRET = process.env.CLIENT_SECRET;
 const GRAPH_CLIENT_DEBUG_LOGGING = isTruthy(process.env.GRAPH_CLIENT_DEBUG_LOGGING);
+const STATUS_POLLING_CRON_PATTERN = process.env.STATUS_POLLING_CRON_PATTERN || '0 0 7 * * *'; 
+const EMAIL_FROM_ADDRESS = process.env.EMAIL_FROM_ADDRESS ?? 'noreply@kaleidos.vlaanderen.be';
+const EMAIL_TO_ADDRESS_ON_FAILURE = process.env.EMAIL_TO_ADDRESS_ON_FAILURE ?? '';
+
+const RESOURCE_BASE_URI  = 'http://themis.vlaanderen.be';
+const EMAIL_GRAPH_URI = "http://mu.semte.ch/graphs/system/email";
+const EMAIL_OUTBOX_URI = "http://themis.vlaanderen.be/id/mail-folders/d9a415a4-b5e5-41d0-80ee-3f85d69e318c";
 
 const RELATIVE_STORAGE_PATH = rstrip(process.env.MU_APPLICATION_FILE_STORAGE_PATH ?? "converted-docx", "/")
 const STORAGE_PATH = `/share/${RELATIVE_STORAGE_PATH}`;
@@ -67,4 +74,10 @@ export {
   STORAGE_PATH,
   FILE_RESOURCE_BASE_URI,
   FILE_JSONAPI_TYPE,
+  STATUS_POLLING_CRON_PATTERN,
+  EMAIL_FROM_ADDRESS,
+  EMAIL_TO_ADDRESS_ON_FAILURE,
+  RESOURCE_BASE_URI,
+  EMAIL_GRAPH_URI,
+  EMAIL_OUTBOX_URI
 }

--- a/lib/email.js
+++ b/lib/email.js
@@ -1,0 +1,41 @@
+import {
+  EMAIL_FROM_ADDRESS,
+  EMAIL_TO_ADDRESS_ON_FAILURE,
+  EMAIL_GRAPH_URI,
+  EMAIL_OUTBOX_URI,
+  RESOURCE_BASE_URI,
+} from "../cfg";
+import { updateSudo as update } from "@lblod/mu-auth-sudo";
+import { uuid, sparqlEscapeUri, sparqlEscapeString } from "mu";
+
+async function createEmailOnFailure(subject, content) {
+  if (!EMAIL_TO_ADDRESS_ON_FAILURE) {
+    console.log(
+      "** Mail not created, there was no email address found to send to on failure **"
+    );
+    return;
+  }
+
+  const id = uuid();
+  const uri = `${RESOURCE_BASE_URI}/email/${id}`;
+
+  const queryString = `
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+PREFIX nmo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#>
+
+INSERT DATA {
+  GRAPH ${sparqlEscapeUri(EMAIL_GRAPH_URI)} {
+    ${sparqlEscapeUri(uri)} a nmo:Email;
+      mu:uuid ${sparqlEscapeString(id)} ;
+      nmo:messageFrom ${sparqlEscapeString(EMAIL_FROM_ADDRESS)} ;
+      nmo:emailTo ${sparqlEscapeString(EMAIL_TO_ADDRESS_ON_FAILURE)} ;
+      nmo:messageSubject ${sparqlEscapeString(subject)} ;
+      nmo:plainTextMessageContent ${sparqlEscapeString(content)} ;
+      nmo:isPartOf ${sparqlEscapeUri(EMAIL_OUTBOX_URI)} .
+  }
+}`;
+  await update(queryString);
+}
+
+export { createEmailOnFailure };

--- a/lib/graph-api.js
+++ b/lib/graph-api.js
@@ -49,8 +49,17 @@ async function deleteFile(file) {
     .delete();
 }
 
+async function checkDefaultDrive() {
+  return await client
+    .api(
+      `/sites/${SITE_ID}/drive`,
+    )
+    .get();
+}
+
 export {
   uploadFile,
   downloadPdf,
   deleteFile,
+  checkDefaultDrive,
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
   "homepage": "https://github.com/sergiofenoll/docx-to-pdf-conversion-via-graph-api-poc#readme",
   "dependencies": {
     "@azure/identity": "^4.0.0",
+    "@lblod/mu-auth-sudo": "^0.6.2",
     "@microsoft/microsoft-graph-client": "^3.0.7",
+    "cron": "^3.1.6",
     "isomorphic-fetch": "^3.0.0"
   }
 }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5050

- Added polling on start
- Added polling based on cronjob (default we check once at 7 am if not changed)
- emails can be sent on failure if the ENV param is provided


Right now we only check the recent issue. "Is the default drive ok".
We could add more status checks in there, perhaps even attempting to convert a test docx file.
Not sure what is possible with the client.
Unsure if you can poll the default drive should your tenant lose the relevant permissions.
or if the access key expires.