### PR TITLE
KAS-5045 KAS-5053 add deletion of file if download fails, delete permanently instead of delete to trash

### DIFF
--- a/lib/graph-api.js
+++ b/lib/graph-api.js
@@ -33,9 +33,11 @@ async function uploadFile(file, fileStream) {
     options,
   );
   await uploadTask.upload();
+  console.log('uploaded the source file');
 }
 
 async function downloadPdf(file) {
+  console.log('going to download the pdf file');
   return await client
     .api(
       `/sites/${SITE_ID}/drive/root:/${file.id}.${file.extension}:/content?format=pdf`,
@@ -44,9 +46,17 @@ async function downloadPdf(file) {
 }
 
 async function deleteFile(file) {
-  await client
-    .api(`/sites/${SITE_ID}/drive/root:/${file.id}.${file.extension}`)
-    .delete();
+  console.log('going to delete the file');
+  // this is not what the API reference says, but it works?
+  // api ref says: "POST /drives/{drive-id}/items/{item-id}/permanentDelete"
+  await client.api(`/sites/${SITE_ID}/drive/root:/${file.id}.${file.extension}:/permanentDelete`)
+    .post();
+
+  // delete to trash bin, not wanted but maybe as backup somehow?
+  // await client
+  //   .api(`/sites/${SITE_ID}/drive/root:/${file.id}.${file.extension}`)
+  //   .delete();
+  console.log('file deleted');
 }
 
 async function checkDefaultDrive() {


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5045
https://kanselarij.atlassian.net/browse/KAS-5053

Combined tickets since I was working on the service.
Could have split but ehh.

Download fails if it takes longer than 45 seconds.
In that case we catch the error, delete the doc from sharepoint (permanently) and then toss the error to the current error handling.
